### PR TITLE
libril: initialise RIL_CallForwardInfo to 0 when requesting status

### DIFF
--- a/ril/libril/ril_service.cpp
+++ b/ril/libril/ril_service.cpp
@@ -679,7 +679,7 @@ bool dispatchCallForwardStatus(int serial, int slotId, int request,
         return false;
     }
 
-    RIL_CallForwardInfo cf;
+    RIL_CallForwardInfo cf = {};
     cf.status = (int) callInfo.status;
     cf.reason = callInfo.reason;
     cf.serviceClass = callInfo.serviceClass;


### PR DESCRIPTION
Some devices have extra pointers in this structure that if non-zero
causes libsec-ril.so to segfault

Change-Id: I9fd07a4747ef0fb1388ebbec472f2dda8dea4003